### PR TITLE
Provided a way to declare a global delimiter

### DIFF
--- a/Outcomes/Formats/MultiLineFormatter.cs
+++ b/Outcomes/Formats/MultiLineFormatter.cs
@@ -10,6 +10,7 @@ namespace Ether.Outcomes.Formats
         /// </summary>
         public static string ToMultiLine(string delimiter, List<string> messages)
         {
+            delimiter = delimiter ?? Outcomes.DefaultDelimiter;
             var result = new StringBuilder();
 
             foreach (var message in messages)

--- a/Outcomes/Outcomes.cs
+++ b/Outcomes/Outcomes.cs
@@ -9,6 +9,11 @@ using JetBrains.Annotations;
 
 namespace Ether.Outcomes
 {
+    //Partial class contains all commons methods.
+    public static partial class Outcomes
+    {
+        public static string DefaultDelimiter { get; set; }
+    }
 
     //Partial class contains all the success-related methods.
     public static partial class Outcomes


### PR DESCRIPTION
Most of the time, I need to use Environment.NewLine instead a single space.
There's no need to repeat my self in all _ToMultiLine_ method call.