### PR TITLE
Added missing interface implementations.

### DIFF
--- a/Outcomes/DeserializableOutcome.cs
+++ b/Outcomes/DeserializableOutcome.cs
@@ -48,7 +48,7 @@ namespace Ether.Outcomes
 #if NET45 || NET40
     [Serializable]
 #endif
-    public class DeserializableOutcome<TValue> : DeserializableOutcome
+    public class DeserializableOutcome<TValue> : DeserializableOutcome, IOutcome, IOutcome<TValue>
     {
         public TValue Value { get; set; }
     }


### PR DESCRIPTION
I forgot to add the interface definition for `IOutcome<TValue>` on the new `DeserializableOutcome<TValue>` class. This commit adds that. Sorry that I missed it the first time!