### PR TITLE
Split WithMessage function to two functions for issue #7

### DIFF
--- a/Outcomes/Builder/FailureOutcomeBuilder.cs
+++ b/Outcomes/Builder/FailureOutcomeBuilder.cs
@@ -40,13 +40,19 @@ namespace Ether.Outcomes.Builder
         /// </summary>
         /// <param name="message">Optional message that will appear after the specified outcome's messages.</param>
         /// <param name="paramList">Shorthand for String.Format</param>
-        public new IFailureOutcomeBuilder<TValue> WithMessage(string message, params object[] paramList)
+        public new IFailureOutcomeBuilder<TValue> WithMessageFormat(string message, params object[] paramList)
         {
-            base.WithMessage(message, paramList);
+            base.WithMessageFormat(message, paramList);
             return this; 
         }
 
-        /// <summary>
+	    public new IFailureOutcomeBuilder<TValue> WithMessage(string message)
+	    {
+		    base.WithMessage(message);
+		    return this;
+	    }
+
+	    /// <summary>
         /// Adds a collection of messages to the end of the outcome's message list.
         /// </summary>
         public new IFailureOutcomeBuilder<TValue> WithMessage(IEnumerable<string> messages)

--- a/Outcomes/Builder/IFailureOutcomeBuilder.cs
+++ b/Outcomes/Builder/IFailureOutcomeBuilder.cs
@@ -23,17 +23,23 @@ namespace Ether.Outcomes.Builder
         /// <summary>
         /// Add a string to the end of the outcome's message collection.
         /// </summary>
-        /// <param name="message">String to add.</param>
+        /// <param name="message">String to add. It can contains string format pattern which will be used by string.Format.</param>
         /// <param name="paramList">Shorthand for String.Format</param>
         /// <returns></returns>
-        IFailureOutcomeBuilder<TValue> WithMessage(string message, params object[] paramList);
+        IFailureOutcomeBuilder<TValue> WithMessageFormat(string message, params object[] paramList);
 
+		/// <summary>
+		/// Add a string to the end of the outcome's message collection.
+		/// </summary>
+		/// <param name="message">String to add.</param>
+		/// <returns></returns>
+		IFailureOutcomeBuilder<TValue> WithMessage(string message);
         /// <summary>
-        /// Append a list of strings to the end of the outcome's message collection.
-        /// </summary>
-        /// <param name="messages">The strings to add.</param>
-        /// <returns></returns>
-        IFailureOutcomeBuilder<TValue> WithMessage(IEnumerable<string> messages);
+		/// Append a list of strings to the end of the outcome's message collection.
+		/// </summary>
+		/// <param name="messages">The strings to add.</param>
+		/// <returns></returns>
+		IFailureOutcomeBuilder<TValue> WithMessage(IEnumerable<string> messages);
 
         /// <summary>
         /// Alternate syntax for FromOutcome. Adds messages from the specified outcome (if any).

--- a/Outcomes/Builder/SuccessOutcomeBuilder.cs
+++ b/Outcomes/Builder/SuccessOutcomeBuilder.cs
@@ -17,13 +17,13 @@ namespace Ether.Outcomes.Builder
         }
 
         /// <summary>
-        /// Add a string to the end of the outcome's message collection.
+        /// Add a formatted string to the end of the outcome's message collection.
         /// </summary>
-        /// <param name="message">String to add.</param>
+        /// <param name="message">String with format pattern to add. The format patterns will be used in string.Format.</param>
         /// <param name="paramList">Shorthand for String.Format</param>
         /// <returns></returns>
         [StringFormatMethod("message")]
-        public SuccessOutcomeBuilder<TValue> WithMessage(string message, params object[] paramList)
+        public SuccessOutcomeBuilder<TValue> WithMessageFormat(string message, params object[] paramList)
         {
             message = string.Format(message, paramList);
 
@@ -31,6 +31,16 @@ namespace Ether.Outcomes.Builder
             return this;
         }
 
+		/// <summary>
+		/// Add a string to the end of the outcome's message collection.
+		/// </summary>
+		/// <param name="message">String to add.</param>
+		/// <returns></returns>
+		public SuccessOutcomeBuilder<TValue> WithMessage(string message)
+	    {
+			base.Messages.Add(message);
+		    return this;
+	    }
         /// <summary>
         /// Append a list of strings to the end of the outcome's message collection.
         /// </summary>


### PR DESCRIPTION
I want to resolve #7 with two functions:

WithMessage function with a single "message" parameter
and WithMessageFormat with additional parameter list. This is to prevent old
WithMessage to use string format pattern in "message" parameter when there is
no parameter passed in.